### PR TITLE
Handle the case when Connect and the add-on server are not in sync

### DIFF
--- a/__tests__/install.js
+++ b/__tests__/install.js
@@ -90,9 +90,25 @@ describe('Installation', () => {
     })
   })
 
+  test('First Jira add-on install from the Connect point of view, but we already have the instance', async () => {
+    const req = { body: jiraPayload, headers: {}, query: {} }
+    const loadCredentials = () => jiraPayload
+
+    const result = await jiraAddon.install(req, {
+      loadCredentials,
+      saveCredentials
+    })
+
+    expect(result.credentials).toEqual(jiraPayload)
+  })
+
   test('Unauthorized request to updated existing instance', async () => {
     const loadCredentials = () => jiraPayload
-    const req = { body: jiraPayload, headers: {}, query: {} }
+    const req = {
+      body: { ...jiraPayload, sharedSecret: 'invalid-secret' },
+      headers: {},
+      query: {}
+    }
 
     await expect(jiraAddon.install(req, {
       loadCredentials,

--- a/lib/Addon.js
+++ b/lib/Addon.js
@@ -17,9 +17,16 @@ class Addon {
       throw new AuthError('Wrong issuer', 'WRONG_ISSUER')
     }
 
-    // Create allowed if nothing was found by id.
+    // 1. Create allowed if nothing was found by id.
     // Sometimes request signed (but we can't validate), sometimes not.
-    if (!credentials) {
+    // 2. Sometimes Connect sends us a request, we save a new instance,
+    // but request fails due to timeout or other reason
+    // and Connect don't get 200 and revert installation.
+    // Next time it sends us an unauthorized request as it would send for the first install,
+    // but we already have this instance in the DB.
+    if (!credentials || (
+      !token && credentials && credentials.sharedSecret === req.body.sharedSecret
+    )) {
       const savedCredentials = await saveCredentials(id, req.body)
       return {
         credentials: savedCredentials || req.body


### PR DESCRIPTION
### Problem

We get some installation webhooks every day for the same sites without the `Authorization` header. And we already have those instances in our DB.

### Explanation

This happens when Connect and the add-on server are not in sync with regard to the installation state of the add-on.
Connect does not believe the addon is installed so the installation payload it sends is not signed (the first install webhook is [not signed](https://developer.atlassian.com/cloud/jira/platform/authentication-for-apps/#signing-outgoing-requests)). Presumably, we have seen the site before, we've created a record in the DB and expect the install to be signed.
We believe this can happen due to a timeout. If the add-on receives an install payload and creates its record but the response does not get to Connect in time, Connect will timeout the install and rollback its install record. The two ends are now out of sync.

### Solution

We can solve this manually by removing those records from our DB, so the next installs will succeed. But this can be automated in this library.

To automate this we just need to do the same as we do on the first install, but not to throw an error, when there's no token but we have this instance. With this solution, I see one issue, when the add-on was installed and then someone sends an unsigned request with a different `sharedSecret`. We would update the record in the DB, but that's it, we couldn't send requests to Jira with the wrong token. So there are no security issues I believe. But just in case I have added a check for `sharedSecret` from request body to match with one we store in DB.

If for any reason Connect recycles `sharedSecret`, then the installation never succeeds.

### Questions

1. Do you think this is a good idea that we can automize this and put the solution to this library or better to fix it manually and decline this PR?
2. Should we check for `sharedSecret` from the request body to match with the existing one in our DB?