### PR TITLE
Wrap express `req` with `jwt.fromExpressRequest` 

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -19,7 +19,15 @@ function validateQsh (req, payload, baseUrl) {
     return
   }
 
-  const expectedHash = jwt.createQueryStringHash(req, false, baseUrl)
+  // The "atlassian-jwt" 1.x.x release brings some breaking changes,
+  // their methods no longer accept the Express.js request object as an argument
+  // but instead use our own intermediate Request object.
+  // "originalUrl" is Express specific, so it allows us to ease the transition.
+  const expectedHash = jwt.createQueryStringHash(
+    req.originalUrl ? jwt.fromExpressRequest(req) : req,
+    false,
+    baseUrl
+  )
 
   if (payload.qsh !== expectedHash) {
     throw new AuthError('Invalid QSH', 'INVALID_QSH')


### PR DESCRIPTION
Since the new version of `atlassian-jwt` doesn't accept Express req directly, we need to wrap it.
[Docs](https://bitbucket.org/atlassian/atlassian-jwt-js/src/master/)

![image](https://user-images.githubusercontent.com/16977959/69536722-34428e00-0f87-11ea-8d5e-27a4bcbd2835.png)

