### PR TITLE
Handle error when we failed to decode token, pass original error to AuthError

### DIFF
--- a/lib/Addon.js
+++ b/lib/Addon.js
@@ -13,7 +13,7 @@ class Addon {
     const token = util.extractToken(req)
     const credentials = await loadCredentials(id)
 
-    if (token && jwt.decode(token, '', true).iss !== id) {
+    if (token && util.extractIssuer(token) !== id) {
       throw new AuthError('Wrong issuer', 'WRONG_ISSUER')
     }
 
@@ -47,7 +47,7 @@ class Addon {
       throw new AuthError('Missed token', 'MISSED_TOKEN')
     }
 
-    const id = jwt.decode(token, '', true).iss
+    const id = util.extractIssuer(token)
     const credentials = await loadCredentials(id)
 
     if (!credentials) {

--- a/lib/AuthError.js
+++ b/lib/AuthError.js
@@ -1,9 +1,10 @@
 class AuthError extends Error {
-  constructor (message, code) {
+  constructor (message, code, originError) {
     super(message)
 
     this.message = message
     this.code = code
+    this.originError = originError
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -14,6 +14,14 @@ function extractId (req, product) {
   return req.body.clientKey
 }
 
+function extractIssuer (token) {
+  try {
+    return jwt.decode(token, '', true).iss
+  } catch (error) {
+    throw new AuthError('Failed to decode token', 'FAILED_TO_DECODE', error)
+  }
+}
+
 function validateQsh (req, payload, baseUrl) {
   if (!payload.qsh) {
     return
@@ -32,7 +40,7 @@ function validateToken (token, sharedSecret) {
   try {
     payload = jwt.decode(token, sharedSecret)
   } catch (error) {
-    throw new AuthError('Invalid signature', 'INVALID_SIGNATURE')
+    throw new AuthError('Invalid signature', 'INVALID_SIGNATURE', error)
   }
 
   const now = Math.floor(Date.now() / 1000)
@@ -47,6 +55,7 @@ function validateToken (token, sharedSecret) {
 module.exports = {
   extractToken,
   extractId,
+  extractIssuer,
   validateQsh,
   validateToken
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3420,6 +3420,12 @@
         "pretty-format": "^24.9.0"
       }
     },
+    "jest-matcher-specific-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-specific-error/-/jest-matcher-specific-error-1.0.0.tgz",
+      "integrity": "sha1-dGCX+yCsNMNtqZ+iDr3Vu/8F0z4=",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "jest-matcher-specific-error": "^1.0.0"
+  },
+  "jest": {
+    "setupFilesAfterEnv": [
+      "jest-matcher-specific-error"
+    ]
   }
 }


### PR DESCRIPTION
* Move extracting issuer to util function, so we can try..catch it
* Handle error when we failed to decode token
* Pass original error object as `originError` to `AuthError`
* Pass original error object to `AuthError` when there's a signature error (not sure about this as it reveals token but it's on the consumer, right?)
* add `jest-matcher-specific-error` for better testing 🥰 