### PR TITLE
Wrap express `req` with `jwt.fromExpressRequest`

### DIFF
--- a/__tests__/auth.js
+++ b/__tests__/auth.js
@@ -169,4 +169,103 @@ describe('Auth', () => {
     expect(result).toHaveProperty('credentials')
     expect(result).toHaveProperty('payload')
   })
+
+  test('Passed Node.js HTTP request object', async () => {
+    const expectedHash = jwt.createQueryStringHash(
+      {
+        body: jiraPayload,
+        query: {},
+        pathname: '/api/install',
+        method: 'POST'
+      },
+      false,
+      baseUrl
+    )
+
+    const token = jwt.encode(
+      {
+        iss: jiraPayload.clientKey,
+        sub: 'test:account-id',
+        qsh: expectedHash
+      },
+      jiraPayload.sharedSecret
+    )
+
+    const req = {
+      body: jiraPayload,
+      headers: { authorization: `JWT ${token}` },
+      query: {},
+      pathname: '/api/install',
+      method: 'POST'
+    }
+
+    const result = await jiraAddon.auth(req, {
+      loadCredentials: () => jiraPayload
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "credentials": Object {
+          "baseUrl": "https://test.atlassian.net",
+          "clientKey": "jira-client-key",
+          "sharedSecret": "shh-secret-cat",
+        },
+        "payload": Object {
+          "iss": "jira-client-key",
+          "qsh": "308ba56cff8ed9ae4d1a5fde6c4add0c3de1c7bdf6ddcb220a8763711645e298",
+          "sub": "test:account-id",
+        },
+      }
+    `)
+  })
+
+  test('Passed Express request object', async () => {
+    const expectedHash = jwt.createQueryStringHash(
+      {
+        body: jiraPayload,
+        query: {},
+        pathname: '/api/install',
+        method: 'POST'
+      },
+      false,
+      baseUrl
+    )
+
+    const token = jwt.encode(
+      {
+        iss: jiraPayload.clientKey,
+        sub: 'test:account-id',
+        qsh: expectedHash
+      },
+      jiraPayload.sharedSecret
+    )
+
+    const req = {
+      body: jiraPayload,
+      headers: { authorization: `JWT ${token}` },
+      query: {},
+      pathname: '/install',
+      originalUrl: '/api/install',
+      method: 'POST'
+    }
+
+    const result = await jiraAddon.auth(req, {
+      loadCredentials: () => jiraPayload
+    })
+
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "credentials": Object {
+          "baseUrl": "https://test.atlassian.net",
+          "clientKey": "jira-client-key",
+          "sharedSecret": "shh-secret-cat",
+        },
+        "payload": Object {
+          "iss": "jira-client-key",
+          "qsh": "308ba56cff8ed9ae4d1a5fde6c4add0c3de1c7bdf6ddcb220a8763711645e298",
+          "sub": "test:account-id",
+        },
+      }
+    `)
+  })
 })

--- a/lib/Addon.js
+++ b/lib/Addon.js
@@ -1,4 +1,3 @@
-const jwt = require('atlassian-jwt')
 const AuthError = require('./AuthError')
 const util = require('./util')
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,7 +27,16 @@ function validateQsh (req, payload, baseUrl) {
     return
   }
 
-  const expectedHash = jwt.createQueryStringHash(req, false, baseUrl)
+  // The "atlassian-jwt" 1.x.x release brings some breaking changes,
+  // their methods no longer accept the Express.js request object as an argument
+  // but instead accepts incoming HTTP Request object that are used to generate a signed JWT.
+  // "originalUrl" is Express specific, so it allows us to ease the transition.
+  // Details: https://bitbucket.org/atlassian/atlassian-jwt-js/src/e672346f3103c7b079868c931af04bd25028af5d/lib/jwt.ts#lines-51:63
+  const expectedHash = jwt.createQueryStringHash(
+    req.originalUrl ? jwt.fromExpressRequest(req) : req,
+    false,
+    baseUrl
+  )
 
   if (payload.qsh !== expectedHash) {
     throw new AuthError('Invalid QSH', 'INVALID_QSH')

--- a/package-lock.json
+++ b/package-lock.json
@@ -4659,6 +4659,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://packages.atlassian.com/api/npm/npm-remote/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha1-eVoaeN1S8HPaDNQrIfnJE4GSP/U=",
+      "dev": true
+    },
     "pretty-format": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.1.0",
     "jest": "^26.6.3",
-    "jest-matcher-specific-error": "^1.0.0"
+    "jest-matcher-specific-error": "^1.0.0",
+    "prettier": "^2.2.1"
   },
   "jest": {
     "setupFilesAfterEnv": [


### PR DESCRIPTION
`atlassian-jwt` introduced a breaking change in `v1.0.0` and now `jwt.createQueryStringHash` accepts only fields from an incoming HTTP Request object that are used to generate a signed JWT. Express has different such fields so in order to make it work we need to convert Express request object with `jwt.fromExpressRequest`.