### PR TITLE
Extract bitbucket clientKey instead of workspace uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # atlassian-connect-auth
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/DanielHreben/atlassian-connect-auth.svg)](https://greenkeeper.io/)
+[![Known Vulnerabilities](https://snyk.io/test/github/DanielHreben/atlassian-connect-auth/badge.svg?targetFile=package.json)](https://snyk.io/test/github/DanielHreben/atlassian-connect-auth?targetFile=package.json)
 
 Helper for handling webhooks from Atlassian products
 
 ```javascript
-const {Addon, AuthError} = require('atlassian-connect-auth')
+const { Addon, AuthError } = require('atlassian-connect-auth')
 
 const addon = new Addon({
   baseUrl: 'https://your-addon-url.com',
-  product: 'jira',
+  product: 'jira', // or 'bitbucket'
 })
 
 const handleInstall = (req, res) => {
@@ -59,6 +59,4 @@ const app = express()
   .post('/api/hooks/jira/installed', handleInstall)
   .post('/api/hooks/jira/uninstalled', handleAuth, handleUninstall)
   .post('/api/hooks/jira/project/created', handleAuth, handleProjectCreated)
-
-
 ```

--- a/lib/Addon.js
+++ b/lib/Addon.js
@@ -8,18 +8,18 @@ class Addon {
   }
 
   async install (req, { loadCredentials, saveCredentials }) {
-    const id = util.extractId(req, this.product)
+    const clientKey = util.extractClientKey(req)
     const token = util.extractToken(req)
-    const credentials = await loadCredentials(id)
+    const credentials = await loadCredentials(clientKey)
 
-    if (token && util.extractIssuer(token) !== id) {
+    if (token && util.extractIssuer(token) !== clientKey) {
       throw new AuthError('Wrong issuer', 'WRONG_ISSUER')
     }
 
-    // Create allowed if nothing was found by id.
+    // Create allowed if nothing was found by clientKey.
     // Sometimes request signed (but we can't validate), sometimes not.
     if (!credentials) {
-      const savedCredentials = await saveCredentials(id, req.body)
+      const savedCredentials = await saveCredentials(clientKey, req.body)
       return {
         credentials: savedCredentials || req.body
       }
@@ -30,7 +30,8 @@ class Addon {
       const payload = util.validateToken(token, credentials.sharedSecret)
       util.validateQsh(req, payload, this.baseUrl)
 
-      const updatedCredentials = await saveCredentials(id, req.body, credentials)
+      const updatedCredentials = await saveCredentials(clientKey, req.body, credentials)
+
       return {
         credentials: updatedCredentials || req.body,
         payload
@@ -41,13 +42,14 @@ class Addon {
   }
 
   async auth (req, { skipQsh, loadCredentials }) {
-    const token = util.extractToken(req, this.product)
+    const token = util.extractToken(req)
+
     if (!token) {
       throw new AuthError('Missed token', 'MISSED_TOKEN')
     }
 
-    const id = util.extractIssuer(token)
-    const credentials = await loadCredentials(id)
+    const clientKey = util.extractIssuer(token)
+    const credentials = await loadCredentials(clientKey)
 
     if (!credentials) {
       throw new AuthError('Unknown issuer', 'UNKNOWN_ISSUER')

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,11 +6,7 @@ function extractToken (req) {
   return token.replace(/^JWT /, '')
 }
 
-function extractId (req, product) {
-  if (product === 'bitbucket') {
-    return req.body.principal.uuid
-  }
-
+function extractClientKey (req) {
   return req.body.clientKey
 }
 
@@ -63,7 +59,7 @@ function validateToken (token, sharedSecret) {
 
 module.exports = {
   extractToken,
-  extractId,
+  extractClientKey,
   extractIssuer,
   validateQsh,
   validateToken


### PR DESCRIPTION
This was a mistake 🤦 

Bitbucket installation webhook does contain both `clientKey` and `uuid` but JWT token in `Authorization` header in incoming webhooks or requests from front-end does not contain `uuid`, only `clientKey`. So we have to stick to `clientKey` for Bitbucket.
BTW, this change means that both Jira and Bitbucket apps are handled in the same way, so `product` property on class `Addon` doesn't do anything. But let's keep it for now.

Thanks @utluiz for spotting this.