### PR TITLE
change staging public key provider URL to us-east-1

### DIFF
--- a/src/publicKeyProvider/KeyProvider.ts
+++ b/src/publicKeyProvider/KeyProvider.ts
@@ -12,7 +12,7 @@ export interface KeyProvider {
  */
 export enum ConnectInstallKeysCdnUrl {
   production = 'https://connect-install-keys.atlassian.com',
-  staging = 'https://cs-migrations--cdn.us-west-1.staging.public.atl-paas.net',
+  staging = 'https://cs-migrations--cdn.us-east-1.staging.public.atl-paas.net',
 }
 
 export type EnvironmentType = keyof typeof ConnectInstallKeysCdnUrl;


### PR DESCRIPTION
The `us-west-1` staging URL no longer serves the right public key due to which installing a Connect app fails on staging. We should switch to us-east-1 instead (as per internal discussion)